### PR TITLE
Fix undeclared variables in routing example

### DIFF
--- a/pages/routing.md
+++ b/pages/routing.md
@@ -48,7 +48,7 @@ r.Get("/articles/{date}-{slug}", getArticle)
 func getArticle(w http.ResponseWriter, r *http.Request) {
   dateParam := chi.URLParam(r, "date")
   slugParam := chi.URLParam(r, "slug")
-  article, err := database.GetArticle(date, slug)
+  article, err := database.GetArticle(dateParam, slugParam)
 
   if err != nil {
     w.WriteHeader(422)


### PR DESCRIPTION
A minor change fixing undeclared variables in the [Routing patterns & url parameters](https://go-chi.io/#/pages/routing?id=routing-patterns-amp-url-parameters) section.