### PR TITLE
Update JWT middleware docs

### DIFF
--- a/pages/middleware.md
+++ b/pages/middleware.md
@@ -775,7 +775,7 @@ func router() http.Handler {
     // the provided authenticator middleware, but you can write your
     // own very easily, look at the Authenticator method in jwtauth.go
     // and tweak it, its not scary.
-    r.Use(jwtauth.Authenticator)
+    r.Use(jwtauth.Authenticator(tokenAuth))
 
     r.Get("/admin", func(w http.ResponseWriter, r *http.Request) {
       _, claims, _ := jwtauth.FromContext(r.Context())


### PR DESCRIPTION
 Authenticator needs tokenAuth passed in now and the jwt repo docs themselves are fine but this chi one could use the update

:) 