### PR TITLE
Change install command format to code block

### DIFF
--- a/pages/getting_started.md
+++ b/pages/getting_started.md
@@ -1,6 +1,8 @@
 ## Installation
 
-`go get -u github.com/go-chi/chi/v5`
+```sh
+go get -u github.com/go-chi/chi/v5
+```
 
 
 ## Running a Simple Server

--- a/quickstart.md
+++ b/quickstart.md
@@ -7,7 +7,9 @@ This tutorial is only to show you how an api would look with chi.
 
 ## Installation
 
-`go get -u github.com/go-chi/chi/v5`
+```sh
+go get -u github.com/go-chi/chi/v5
+```
 
 
 ## Running a Simple Server


### PR DESCRIPTION
Improves developer experience by changing the install command format from single backtick (code) to double backticks (code block), providing copy to clipboard button.